### PR TITLE
parity between best individual runner and run_cmaes

### DIFF
--- a/cmaes_framework/best_individual_latest.py
+++ b/cmaes_framework/best_individual_latest.py
@@ -66,7 +66,7 @@ def get_best_from_all_csvs():
     return best_row, best_file
 
 
-def visualize_best(mode, logs):
+def visualize_best(mode, logs, hidden_sizes, input_method):
     """
     Continuously run the best individual across all CSVs.
     """
@@ -94,10 +94,10 @@ def visualize_best(mode, logs):
                 # Make video directory if we're making a video.
                 if mode in ["v", "b"]:
                     os.makedirs(vid_path, exist_ok=True)
-                    run(ITERS, genome, mode, HIDDEN_SIZES, vid_name, vid_path, logs, log_filename)
+                    run(ITERS, genome, mode, hidden_sizes, vid_name, vid_path, logs, log_filename, snn_input_method=input_method)
                     quit()
                 elif mode in ["s", "h"]:
-                    run(ITERS, genome, mode, HIDDEN_SIZES, None, None, logs, log_filename)
+                    run(ITERS, genome, mode, hidden_sizes, None, None, logs, log_filename, snn_input_method=input_method)
                     if logs:
                         quit()
             except Exception as e:
@@ -110,11 +110,18 @@ if __name__ == "__main__":
     parser.add_argument(
         '--mode', help='mode for output. h-headless , s-screen, v-video, b-both', default="s")
     parser.add_argument(
-        '--mode', #headless, screen, video, both h, s, v, b
-        help='mode for output. h-headless , s-screen, v-video, b-both',
-        default="s")
-    parser.add_argument(
         '--logs', type=str, help='whether to generate SNN logs (true/false)', default="True")
+    parser.add_argument(
+        '--hidden_sizes',
+        type=int,
+        nargs='+',
+        help='hidden layer sizes for the SNN (default: [2])',
+        default=[1])
+    parser.add_argument(
+        '--input_method',
+        type=str,
+        help='input method for the SNN (default: "corners")',
+        default="corners")
 
 
     args = parser.parse_args()
@@ -127,4 +134,4 @@ if __name__ == "__main__":
     else:
         raise argparse.ArgumentTypeError('Boolean value expected.')
 
-    visualize_best(args.mode, logs)
+    visualize_best(args.mode, logs, args.hidden_sizes, args.input_method)

--- a/cmaes_framework/run_cmaes.py
+++ b/cmaes_framework/run_cmaes.py
@@ -45,7 +45,7 @@ ROBOT_CONFIG_PATH_DEFAULT = "bestbot.json"
 SNN_INPUT_METHOD_DEFAULT = "corners"
 DEFAULT_SCALE_SNN_INPUTS = True
 
-HIDDEN_SIZES = [2]
+HIDDEN_SIZES = [1]
 
 VERBOSE = False
 
@@ -90,7 +90,7 @@ def run(mode,
                               robot_config_path)
 
     NUM_ACTUATORS, SNN_INPUT_SHAPE = snn_controller.compute_genome_size(
-        robot_path, snn_input_method, HIDDEN_SIZES)
+        robot_path, snn_input_method, hidden_sizes)
 
     # Mean genome
     MEAN_ARRAY = [0.0] * SNN_INPUT_SHAPE
@@ -229,13 +229,17 @@ if __name__ == "__main__":
     parser.add_argument('--hidden_sizes',
                         type=int,
                         nargs='+',
-                        default=[2],
+                        default=[1],
                         help='list of hidden layer sizes')
+    parser.add_argument('--input_method',
+                        type=str,
+                        default=SNN_INPUT_METHOD_DEFAULT,
+                        help='input method for the SNN (default: "corners")')
     args = parser.parse_args()
 
     run(args.mode,
         args.gens,
         args.sigma,
         args.hidden_sizes,
-        snn_input_method="all_dist",
+        args.input_method,
         scale_snn_inputs=False)


### PR DESCRIPTION
# Description

I have changed the argparse methods to make it easier to run. The defaults are now the same between best_individual_latest and run_cmaes. The input method is now included in the CMA-ES argparse and defaults to 'corners'

## Checklist

<!--- (please complete) -->
- [x]  I have read the guidelines in CONTRIBUTING.md
- [x]  I have formatted my code using yapf
- [x]  I have linted my code with pylint
- [x]  I have added a one-line description of my change to the changelog in HISTORY.md
- [x]  This PR is ready
